### PR TITLE
Small improvements to _oasis file

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -6,7 +6,7 @@ Authors: Francois Berenger
 License: BSD3
 Plugins: META (0.3)
 
-if flag(test)
+if flag(tests)
   PreBuildCommand: qtest -o test.ml extract vector3.ml
 
 BuildTools: ocamlbuild
@@ -18,7 +18,7 @@ Library vector3
 Executable test
   Path: .
   Install: false
-  Build$: flag(test)
+  Build$: flag(tests)
   MainIs: test.ml
   CompiledObject: best
   BuildDepends: oUnit, QTest2Lib, vector3

--- a/_oasis
+++ b/_oasis
@@ -1,4 +1,4 @@
-OASISFormat: 0.3
+OASISFormat: 0.4
 Name: vector3
 Version: 0.1
 Synopsis: module for 3D vectors (implemented as records of x, y and z floats)

--- a/_oasis
+++ b/_oasis
@@ -6,7 +6,8 @@ Authors: Francois Berenger
 License: BSD3
 Plugins: META (0.3)
 
-PreBuildCommand: qtest -o test.ml extract vector3.ml
+if flag(test)
+  PreBuildCommand: qtest -o test.ml extract vector3.ml
 
 BuildTools: ocamlbuild
 
@@ -17,9 +18,10 @@ Library vector3
 Executable test
   Path: .
   Install: false
+  Build$: flag(test)
   MainIs: test.ml
   CompiledObject: best
-  BuildDepends: oUnit, QTest2Lib
+  BuildDepends: oUnit, QTest2Lib, vector3
 
 Test unit
   WorkingDirectory: .


### PR DESCRIPTION
Avoid to build test when not enabled, this cut the dependencies to qtest/ounit when final user doesn't want to run test.

Although add vector3 as a build depends to test, but maybe it doesn't work, feel free to remove it in this case.
