### PR TITLE
improved error message for the function of_string

### DIFF
--- a/vector3.ml
+++ b/vector3.ml
@@ -52,6 +52,11 @@ let of_string str =
                     y = y ;
                     z = z })
 
+let of_string str =
+  try of_string str
+  with Scanf.Scan_failure msg ->
+    invalid_arg ("Vector3.of_string: " ^ msg)
+
 (* to other types ---------------------------------------------------------- *)
 
 let to_triplet v =


### PR DESCRIPTION
improved error message for the function of_string,
providing an Invalid_argument exception, with the module/function name and the message from the Scanf.Scan_failure exception which describes where the read error is.
